### PR TITLE
Fix ilog2ceil

### DIFF
--- a/stream_compaction/common.h
+++ b/stream_compaction/common.h
@@ -27,7 +27,7 @@ inline int ilog2(int x) {
 }
 
 inline int ilog2ceil(int x) {
-    return ilog2(x - 1) + 1;
+    return if x == 1 : 0 ? ilog2(x - 1) + 1;
 }
 
 namespace StreamCompaction {


### PR DESCRIPTION
`ilog2ceil` now gives the correct answer when `x` is `1`.

To see the change more clearly, append `&w=1` to the url!